### PR TITLE
Bump Netty version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val shimsVersion = "2.0.0"
 val slf4jVersion = "1.7.25"
 val specsVersion = "4.7.1"
 val refinedVersion = "0.9.9"
-val nettyVersion = "4.1.38.Final"
+val nettyVersion = "4.1.49.Final"
 val jsrVersion = "3.0.2"
 val jschVersion = "0.1.55"
 


### PR DESCRIPTION
This is just to make the Netty version match up across all artifacts with respect to https://github.com/precog/async-blobstore/pull/98/files#diff-fdc3abdfd754eeb24090dbd90aeec2ceR20