### PR TITLE
Rewrite to droste and iota

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,3 +1,3 @@
 {
-  "precog-quasar": "178.0.1"
+  "precog-quasar": "178.0.1-03e4b08"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -50,13 +50,16 @@ lazy val root = project
   .aggregate(core)
 
 val mongoVersion = "2.7.0"
-val catsEffectVersion = "2.0.0"
 val shimsVersion = "2.0.0"
 val slf4jVersion = "1.7.25"
 val specsVersion = "4.7.1"
 val refinedVersion = "0.9.9"
 val jsrVersion = "3.0.2"
 val jschVersion = "0.1.55"
+val catsEffectVersion   = "2.1.0"
+val iotaVersion = "0.3.10"
+val drosteVersion = "0.8.0"
+val catsMTLVersion = "0.7.0"
 
 lazy val core = project
   .in(file("datasource"))
@@ -70,10 +73,12 @@ lazy val core = project
     quasarPluginDependencies ++= Seq(
       "com.codecommit"             %% "shims"                      % shimsVersion,
       "eu.timepit"                 %% "refined-scalacheck"         % refinedVersion,
+      "io.higherkindness"          %% "droste-core"                % drosteVersion,
+      "io.frees"                   %% "iota-core"                  % iotaVersion,
       "org.typelevel"              %% "cats-effect"                % catsEffectVersion,
+      "org.typelevel"              %% "cats-mtl-core"              % catsMTLVersion,
       "org.mongodb.scala"          %% "mongo-scala-driver"         % mongoVersion,
       "com.jcraft"                 % "jsch"                        % jschVersion,
-
       "com.precog"                 %% "quasar-foundation"          % managedVersions.value("precog-quasar") % Test classifier "tests",
       "com.precog"                 %% "quasar-frontend"            % managedVersions.value("precog-quasar") % Test classifier "tests",
       "org.slf4j"                  %  "slf4j-log4j12"              % slf4jVersion % Test,
@@ -85,4 +90,5 @@ lazy val core = project
       // warnings w/o this dependency
       "com.google.code.findbugs"   %  "jsr305"                      % jsrVersion % Provided
     ))
+  .evictToLocal("QUASAR_PATH", "foundation", true)
   .enablePlugins(QuasarPlugin)

--- a/datasource/src/main/scala/quasar/physical/mongo/Interpreter.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/Interpreter.scala
@@ -18,79 +18,82 @@ package quasar.physical.mongo
 
 import slamdata.Predef._
 
-import cats.effect.Sync
-
-import org.bson.BsonDocument
-
-import quasar.{ScalarStage, ScalarStages}
-import quasar.IdStatus
-import quasar.physical.mongo.interpreter.{InterpretationState, _}
+import quasar.{ScalarStage, ScalarStages, IdStatus}
 import quasar.physical.mongo.expression._
-import quasar.physical.mongo.utils._
+import quasar.physical.mongo.interpreter._
 
-import scalaz.{BindRec, \/, Scalaz, PlusEmpty}, Scalaz._
+import cats.{Applicative, Monad, MonoidK}
+import cats.effect.Sync
+import cats.implicits._
+import cats.mtl.implicits._
+import higherkindness.droste.Basis
+import higherkindness.droste.data.Fix
 
-import shims._
+import org.bson._
 
-final case class Interpretation(
-  stages: List[ScalarStage],
-  docs: List[BsonDocument])
-
-class Interpreter(version: Version, uniqueKey: String, pushdownLevel: PushdownLevel) {
-  private def refine(inp: Interpretation)
-      : InState[Interpretation \/ Interpretation] = inp.stages match {
-    case List() => inp.right[Interpretation].point[InState]
-    case hd :: tail =>
-      val nextStep = for {
-        pipes <- interpretStep[InState](hd)
-        docs <- compilePipeline[InState](version, uniqueKey, pipes)
-      } yield Interpretation(tail, inp.docs ++ docs).left[Interpretation]
-      nextStep <+> inp.right[Interpretation].point[InState]
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  def interpretStep[F[_]: MonadInState: PlusEmpty](instruction: ScalarStage): F[List[Pipe]] = instruction match {
-    case ScalarStage.Wrap(name) =>
-      optToAlternative[F].apply(Projection.safeField(name)) flatMap (Wrap[F](_))
-    case ScalarStage.Mask(masks) =>
-      Mask[F](masks)
-    case ScalarStage.Pivot(status, structure) =>
-      Pivot[F](status, structure)
-    case ScalarStage.Project(path) =>
-      optToAlternative[F].apply(Projection.fromCPath(path)) flatMap (Project[F](_))
-    case ScalarStage.Cartesian(cartouches) =>
-      if (pushdownLevel < PushdownLevel.Full) PlusEmpty[F].empty
-      else optToAlternative[F].apply(Projection.safeCartouches(cartouches)) flatMap (Cartesian[F](_, interpretStep[F]))
-  }
-
-  private def initial[F[_]: MonadInState](idStatus: IdStatus): F[List[Pipe]] = idStatus match {
-    case IdStatus.IdOnly =>
-      focus[F] as List(Pipeline.$project(Map(
-        uniqueKey -> O.key("_id"),
-        "_id" -> O.int(0))))
-    case IdStatus.ExcludeId =>
-      List[Pipe]().point[F]
-    case IdStatus.IncludeId =>
-      focus[F] as List(Pipeline.$project(Map(
-        uniqueKey -> O.array(List(O.key("_id"), O.steps(List()))),
-        "_id" -> O.int(0))))
-  }
-
-  def interpret(stages: ScalarStages): (Interpretation, Mapper) = {
-    val interpreted = for {
-      firstPipes <- initial[InState](stages.idStatus)
-      firstDocs <- firstPipes foldMapM (compilePipe[InState](version, uniqueKey, _))
-      result <- BindRec[InState].tailrecM(refine)(Interpretation(stages.stages, firstDocs))
-    } yield result
-    interpreted.run(InterpretationState(uniqueKey, Mapper.Unfocus)) match {
-      case None =>
-        (Interpretation(stages.stages, List()), Mapper.Unfocus)
-      case Some((state, a)) => (a, state.mapper)
-    }
-  }
+trait Interpreter[F[_], U, -S] {
+  def o(implicit U: Basis[Expr, U]) = Optics.full(Optics.basisPrism[Expr, U])
+  def apply(s: S): F[List[Pipeline[U]]]
 }
 
 object Interpreter {
-  def apply[F[_]: Sync](version: Version, pushdownLevel: PushdownLevel): F[Interpreter] =
-    Sync[F].delay(java.util.UUID.randomUUID().toString) map (new Interpreter(version, _, pushdownLevel))
+  def interpretStage[F[_]: Monad: MonadInState: MonoidK, U: Basis[Expr, ?]](pushdown: PushdownLevel): Interpreter[F, U, ScalarStage] =
+    new Interpreter[F, U, ScalarStage] {
+      def apply(s: ScalarStage) =
+        if (pushdown < PushdownLevel.Light)
+          MonoidK[F].empty[List[Pipeline[U]]]
+        else s match {
+          case a: ScalarStage.Wrap => Wrap[F, U].apply(a)
+          case a: ScalarStage.Mask => Mask[F, U].apply(a)
+          case a: ScalarStage.Pivot => Pivot[F, U].apply(a)
+          case a: ScalarStage.Project => Project[F, U].apply(a)
+          case _: ScalarStage.Cartesian if pushdown < PushdownLevel.Full => MonoidK[F].empty[List[Pipeline[U]]]
+          case a: ScalarStage.Cartesian => Cartesian[F, U](interpretStage[F, U](pushdown)).apply(a)
+        }
+    }
+  def interpretIdStatus[F[_]: Applicative: MonadInState, U: Basis[Expr, ?]](uq: String): Interpreter[F, U, IdStatus] =
+    new Interpreter[F, U, IdStatus] {
+      def apply(s: IdStatus) = s match {
+        case IdStatus.IdOnly =>
+          focus[F] as List(Pipeline.Project(Map(
+            uq -> o.str("$_id"),
+            "_id" -> o.int(0))))
+        case IdStatus.ExcludeId =>
+          List[Pipeline[U]]().pure[F]
+        case IdStatus.IncludeId =>
+          focus[F] as List(Pipeline.Project(Map(
+            uq -> o.array(List(o.str("$_id"), o.steps(List()))),
+            "_id" -> o.int(0))))
+      }
+    }
+  final case class Interpretation(stages: List[ScalarStage], docs: List[BsonDocument])
+  type Interpret = ScalarStages => (Interpretation, Mapper)
+
+  def interpret(version: Version, pushdown: PushdownLevel, uuid: String): Interpret = { stages =>
+    val stage = interpretStage[InState, Fix[Expr]](pushdown)
+    val idStatus = interpretIdStatus[InState, Fix[Expr]](uuid)
+    def refine(inp: Interpretation): InState[Either[Interpretation, Interpretation]] = inp.stages match {
+      case List() => inp.asRight[Interpretation].pure[InState]
+      case hd :: tail =>
+        val nextStep = for {
+          pipes <- stage.apply(hd)
+          docs <- Compiler.compile[InState, Fix[Expr]](version, uuid, pipes)
+        } yield Interpretation(tail, inp.docs ++ docs).asLeft[Interpretation]
+        nextStep <+> inp.asRight.pure[InState]
+      }
+    val interpreted = for {
+      initPipes <- idStatus(stages.idStatus)
+      initDocs <- Compiler.compile[InState, Fix[Expr]](version, uuid, initPipes)
+      refined <- Monad[InState].tailRecM(Interpretation(stages.stages, initDocs))(refine)
+    } yield refined
+    interpreted.run(InterpretationState(uuid, Mapper.Unfocus)) match {
+      case None =>
+        (Interpretation(stages.stages, List()), Mapper.Unfocus)
+      case Some((state, a)) =>
+        (a, state.mapper)
+    }
+  }
+
+  def apply[F[_]: Sync](version: Version, pushdown: PushdownLevel): F[Interpret] =
+    Sync[F].delay(java.util.UUID.randomUUID.toString) map (interpret(version, pushdown, _))
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Compiler.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Compiler.scala
@@ -40,7 +40,7 @@ object Compiler {
     scheme.cata[CoreOp, U, Version](Algebra { (x: CoreOp[Version]) =>
       val order = Order[Version]
       import order._
-      CopK.RemoveL[Op, CoreOpL].apply(x) match{
+      CopK.RemoveL[Op, CoreOpL].apply(x) match {
         case Left(a) =>
           Version.zero
         case Right(x) =>
@@ -258,9 +258,9 @@ object Compiler {
         case Right(a) => a match {
           case Core.Null() =>
             new BsonNull()
-          case Core.SInt(i) =>
+          case Core.Int(i) =>
             new BsonInt32(i)
-          case Core.SString(s) =>
+          case Core.String(s) =>
             new BsonString(s)
           case Core.Bool(b) =>
             new BsonBoolean(b)

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Compiler.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Compiler.scala
@@ -18,259 +18,286 @@ package quasar.physical.mongo.expression
 
 import slamdata.Predef._
 
-import matryoshka._
-import matryoshka.implicits._
+import quasar.physical.mongo.Version
+import quasar.contrib.iotac._
 
-import monocle._
+import cats._
+import cats.data.Const
+import cats.implicits._
+import higherkindness.droste.{Basis, scheme, Algebra, CVCoalgebra}
+import higherkindness.droste.data._
+import higherkindness.droste.syntax.all._
+import iota.CopK
+import monocle.Prism
 
 import org.bson._
 
-import quasar.physical.mongo.Version
-
-import scalaz.{:<:, Const, Coproduct, Functor, Scalaz, MonadPlus, ApplicativePlus, Free}, Scalaz._
-import scalaz.syntax._
-
 import Pipeline._
+import Projection._
 
 object Compiler {
-  type CoreOp[A] = Coproduct[Op, Core, A]
-  type ExprF[A] = Coproduct[Const[Projection, ?], CoreOp, A]
+  def coreOpMinVersion[U: Basis[CoreOp, ?]]: U => Version =
+    scheme.cata[CoreOp, U, Version](Algebra { (x: CoreOp[Version]) =>
+      val order = Order[Version]
+      import order._
+      CopK.RemoveL[Op, CoreOpL].apply(x) match{
+        case Left(a) =>
+          Version.zero
+        case Right(x) =>
+          val fMin = x.minVersion
+          x match {
+            case Op.Let(vars, in) =>
+              order.max(vars.toList.map(_._2).foldLeft(in)(max), fMin)
+            case Op.Type(a) =>
+              max(fMin, a)
+            case Op.Eq(a) =>
+              a.foldLeft(fMin)(max)
+            case Op.Or(a) =>
+              a.foldLeft(fMin)(max)
+            case Op.Cond(a, b, c) =>
+              List(a, b, c).foldLeft(fMin)(max)
+            case Op.Ne(a) =>
+              max(fMin, a)
+            case Op.ObjectToArray(a) =>
+              max(fMin, a)
+            case Op.ArrayElemAt(a, _) =>
+              max(fMin, a)
+            case Op.Reduce(a, b ,c) =>
+              List(a, b, c).foldLeft(fMin)(max)
+            case Op.ConcatArrays(a) =>
+              a.foldLeft(fMin)(max)
+            case Op.Not(a) =>
+              max(fMin, a)
+            case Op.Exists(a) =>
+              max(fMin, a)
+          }
+      }
+    })
 
-  def compilePipeline[T[_[_]]: BirecursiveT, F[_]: MonadPlus](
-      version: Version,
-      uuid: String,
-      pipes: List[Pipeline[T[ExprF]]])
-      : F[List[BsonDocument]] =
-    pipes flatMap (eraseCustomPipeline(uuid, _)) foldMapM { x => compilePipe[T, F](version, uuid, x) map (List(_)) }
+  def compileOp[W: Basis[CoreOp, ?], U: Basis[Core0, ?]]: W => U = {
+    val core0 = Optics.core(Optics.basisPrism[Core0, U])
+    import core0._
+    scheme.cata[CoreOp, W, U](Algebra { (x: CoreOp[U]) =>
+      CopK.RemoveL[Op, CoreOpL].apply(x) match {
+        case Left(a) =>
+          computeListK(a).embed
+        case Right(b) => b match {
+          case Op.Let(vars, in) => obj(Map("$let" -> obj(Map("vars" -> obj(vars), "in" -> in))))
+          case Op.Type(a) => obj(Map("$type" -> a))
+          case Op.Eq(a) => obj(Map("$eq" -> array(a)))
+          case Op.Or(a) => obj(Map("$or" -> array(a)))
+          case Op.Exists(a) => obj(Map("$exists" -> a))
+          case Op.Cond(a, b, c) => obj(Map("$cond" -> array(List(a, b, c))))
+          case Op.Ne(a) => obj(Map("$ne" -> a))
+          case Op.ObjectToArray(a) => obj(Map("$objectToArray" -> a))
+          case Op.ArrayElemAt(a, ix) => obj(Map("$arrayElemAt" -> array(List(a, int(ix)))))
+          case Op.Reduce(a, b, c) => obj(Map("$reduce" -> obj(Map(
+            "input" -> a,
+            "initialValue" -> b,
+            "in" -> c))))
+          case Op.ConcatArrays(a) => obj(Map("$concatArrays" -> array(a)))
+          case Op.Not(a) => obj(Map("$not" -> a))
+        }
+      }
+    })
+  }
 
-  def toCoreOp[T[_[_]]: BirecursiveT](uuid: String, pipe: MongoPipeline[T[ExprF]]): T[CoreOp] =
-    optimize(compileProjections(uuid, pipelineObjects(pipe)))
+  type Elem = (Projection.Grouped, Int)
+  private def unfoldProjectionψ(uuid: String): CVCoalgebra[CoreOp, List[Elem]] = {
+    type U = Coattr[CoreOp, List[Elem]]
+    type F[X] = CoattrF[CoreOp, List[Elem], X]
 
-  def compilePipe[T[_[_]]: BirecursiveT, F[_]: MonadPlus](
-      version: Version,
-      uuid: String,
-      pipe: MongoPipeline[T[ExprF]])
-      : F[BsonDocument] = {
-    if (version < pipeMinVersion(pipe)) MonadPlus[F].empty
-    else {
-      def transformM(op: Op[T[Core]]): F[Core[T[Core]]] =
-        if (version < Op.opMinVersion(op)) MonadPlus[F].empty
-        else opsToCore[T](op).point[F]
+    val toCopK = Optics.basisPrism[F, U] composePrism Optics.coattrFPrism[CoreOp, List[Elem], U]
+    val ff = Optics.coreOp(Prism.id: Prism[CoreOp[U], CoreOp[U]])
+    val coreOp = Optics.coreOp(toCopK)
+    import coreOp._
 
-      toCoreOp(uuid, pipe)
-        .transCataM[F, T[Core], Core](_.run.fold(transformM, MonadPlus[F].point(_)))
-        .map(coreToBson[T](_))
-        .flatMap(mbBsonDocument[F])
+    CVCoalgebra {
+      case List() =>
+        ff.str("$$ROOT")
+      case (Grouped.FieldGroup(hd :: tail), _) :: List() =>
+        ff.str(tail.foldLeft("$".concat(hd)){ (acc, s) => s"$acc.$s" })
+      case (hd, levelIx) :: tl =>
+        val level = s"level${levelIx.toString}"
+        val tailCont: U = Coattr.pure(tl)
+        val undefined = str(s"$uuid$MissingSuffix")
+        hd match {
+          case Grouped.IndexGroup(i) =>
+            ff.let(
+              Map(level -> tailCont),
+              cond(
+                eqx(List(typ(tailCont), str("array"))),
+                arrayElemAt(str("$$".concat(level)), i),
+                undefined))
+          case Grouped.FieldGroup(steps) =>
+            val expSteps = Grouped.FieldGroup("$".concat(level) :: steps)
+            val exp: U = Coattr.pure(List((expSteps, 0)))
+            ff.let(
+              Map(level -> tailCont),
+              exp)
+      }
     }
   }
 
-  def mbBsonDocument[F[_]: ApplicativePlus](inp: BsonValue): F[BsonDocument] = inp match {
-    case x: BsonDocument => x.point[F]
-    case _ => ApplicativePlus[F].empty
+  private def unfoldProjection[U: Basis[CoreOp, ?]](uuid: String): Projection => U = { (prj: Projection) =>
+    val grouped = Projection.Grouped(prj).zipWithIndex
+    val fn: List[Elem] => U = scheme.zoo.futu(unfoldProjectionψ(uuid))
+    fn(grouped)
   }
 
-  val MissingSuffix = "_missing"
+  def compileProjections[U: Basis[Expr, ?], W: Basis[CoreOp, ?]](uuid: String): U => W =
+    scheme.cata[Expr, U, W](Algebra { x =>
+      CopK.RemoveL[Const[Projection, ?], ExprL].apply(x) match {
+        case Left(a) =>
+          computeListK(a).embed
+        case Right(Const(prj)) =>
+          val fn = unfoldProjection[W](uuid)
+          fn(prj)
+      }
+    })
 
-  def missing[T[_[_]]: BirecursiveT, F[_]: Functor](key: String)(implicit F: Core :<: F): T[F] = {
-    val O = Optics.core(birecursiveIso[T[F], F].reverse.asPrism)
-    O.string(key concat MissingSuffix)
-  }
-
-  def missingKey[T[_[_]]: BirecursiveT, F[_]: Functor](key: String)(implicit F: Core :<: F): T[F] = {
-    val O = Optics.core(birecursiveIso[T[F], F].reverse.asPrism)
-    O.string("$" concat key concat MissingSuffix)
-  }
-
-  def eraseCustomPipeline[T[_[_]]: BirecursiveT](
+  def eraseCustomPipeline[F[a] <: ACopK[a], U](
       uuid: String,
-      pipeline: Pipeline[T[ExprF]])
-      : List[MongoPipeline[T[ExprF]]] = {
-
-    val O = Optics.fullT[T, ExprF]
+      pipeline: Pipeline[U])(
+      implicit
+      IC: Core :<<: F,
+      IO: Op :<<: F,
+      U: Basis[F, U])
+      : List[MongoPipeline[U]] = {
+    val o = Optics.coreOp(Optics.basisPrism[F, U])
+    import o._
 
     pipeline match {
       case Presented =>
-        List($match(O.obj(Map(uuid -> O.$ne(missing(uuid))))))
+        List(Match(obj(Map(uuid -> nex(missing[F, U](uuid))))))
       case Erase =>
-        List($match(O.obj(Map(uuid.concat("_erase") -> O.bool(false)))))
-      case $project(obj) =>
-        List($project(obj))
-      case $match(obj) =>
-        List($match(obj))
-      case $unwind(a, i) =>
-        List($unwind(a, i))
+        List(Match(obj(Map(uuid.concat("_erase") -> bool(false)))))
+      case Project(obj) =>
+        List(Project(obj))
+      case Match(obj) =>
+        List(Match(obj))
+      case Unwind(a, i) =>
+        List(Unwind(a, i))
     }
   }
 
-  def pipelineObjects[T[_[_]]: BirecursiveT](pipe: MongoPipeline[T[ExprF]]): T[ExprF] = {
-    val O = Optics.fullT[T, ExprF]
+  def pipelineObjects[F[a] <: ACopK[a], U](pipe: MongoPipeline[U])(implicit I: Core :<<: F, U: Basis[F, U]): U = {
+    val o = Optics.core(Optics.basisPrism[F, U])
     pipe match {
-      case $match(mp) =>
-        O.obj(Map("$match" -> mp))
-      case $project(mp) =>
-        O.obj(Map("$project" -> O.obj(mp)))
-      case $unwind(path, arrayIndex) =>
-        O.obj(Map("$unwind" -> O.obj(Map(
-          "path" -> O.string("$" concat path),
-          "includeArrayIndex" -> O.string(arrayIndex),
-          "preserveNullAndEmptyArrays" -> O.bool(false)))))
+      case Match(mp) =>
+        o.obj(Map("$match" -> mp))
+      case Project(mp) =>
+        o.obj(Map("$project" -> o.obj(mp)))
+      case Unwind(path, arrayIndex) =>
+        o.obj(Map("$unwind" -> o.obj(Map(
+          "path" -> o.str("$".concat(path)),
+          "includeArrayIndex" -> o.str(arrayIndex),
+          "preserveNullAndEmptyArrays" -> o.bool(false)))))
     }
   }
 
-  def unfoldProjection[T[_[_]]: BirecursiveT](uuid: String, prj: Projection): T[CoreOp] = {
-    trait GroupedSteps
-    final case class IndexGroup(i: Int) extends GroupedSteps
-    final case class FieldGroup(s: List[String]) extends GroupedSteps
-
-    def groupSteps(prj: Projection): List[GroupedSteps] = {
-      val accum = prj.steps.foldl ((List[String](), List[GroupedSteps]())) {
-        case (fldAccum, accum) => {
-          case Field(s) => (s :: fldAccum, accum)
-          case Index(i) => (List(), IndexGroup(i) :: FieldGroup(fldAccum.reverse) :: accum)
-        }
-      }
-      accum._1 match {
-        case List() => accum._2.reverse
-        case x => (FieldGroup(x.reverse) :: accum._2).reverse
-      }
-    }
-    type Elem = (GroupedSteps, Int)
-
-    type FCoreOp = Free[CoreOp, List[Elem]]
-    val OF = Optics.coreOp(Prism.id[CoreOp[FCoreOp]])
-    val O = Optics.coreOp(Prism.id[CoreOp[List[Elem]]])
-
-    val ψ: GCoalgebra[Free[CoreOp, ?], CoreOp, List[Elem]] = {
-      case List() =>
-        OF.string("$$ROOT")
-      case (FieldGroup(hd :: tail), _) :: List() =>
-        OF.string(tail.foldl("$" concat hd) { accum => s => accum concat "." concat s  })
-      case (hd, levelIx) :: tl => hd match {
-        case IndexGroup(i) =>
-          val level = "level" concat levelIx.toString
-          val vars = Map(level -> (Free.point[CoreOp, List[Elem]](tl)))
-          val nil: FCoreOp = Free.liftF(O.string(uuid concat MissingSuffix))
-          val levelExp: FCoreOp = Free.liftF(O.string("$$" concat level))
-          val elemAt: FCoreOp = Free.roll(OF.$arrayElemAt(levelExp, i))
-          val check: FCoreOp = {
-            val ty: FCoreOp = Free.liftF(O.$type(tl))
-            val str: FCoreOp = Free.liftF(O.string("array"))
-            Free.roll(OF.$eq(List(ty, str)))
-          }
-          val cond = Free.roll(OF.$cond(check, elemAt, nil))
-          OF.$let(vars, cond)
-        case FieldGroup(steps) =>
-          val level = "level".concat(levelIx.toString)
-          val vars: Map[String, FCoreOp] = Map(level -> (Free.point(tl)))
-          val expSteps: GroupedSteps = FieldGroup("$".concat(level) :: steps)
-          val exp: FCoreOp = Free.point(List((expSteps, 0)))
-          OF.$let(vars, exp)
-      }
-    }
-    groupSteps(prj).zipWithIndex.reverse.futu[T[CoreOp]](ψ)
-  }
-
-  def compileProjections[T[_[_]]: BirecursiveT](uuid: String, inp: T[ExprF]): T[CoreOp] = {
-    def τ(inp: Const[Projection, T[CoreOp]]): CoreOp[T[CoreOp]] =
-      unfoldProjection(uuid, inp.getConst).project
-    inp.transCata[T[CoreOp]](_.run.fold(τ, (x => x)))
-  }
-
-  def opsToCore[T[_[_]]: BirecursiveT](inp: Op[T[Core]]): Core[T[Core]] = {
-    val O = Optics.core(birecursiveIso[T[Core], Core].reverse.asPrism)
-    inp match {
-      case Op.Let(vars, in) => O._obj(Map("$let" -> O.obj(Map(
-        "vars" -> O.obj(vars),
-        "in" -> in))))
-      case Op.Type(a) => O._obj(Map("$type"-> a))
-      case Op.Eq(a) => O._obj(Map("$eq" -> O.array(a)))
-      case Op.Or(a) => O._obj(Map("$or" -> O.array(a)))
-      case Op.Exists(a) => O._obj(Map("$exists" -> a))
-      case Op.Cond(a, b, c) => O._obj(Map("$cond" -> O.array(List(a, b, c))))
-      case Op.Ne(a) => O._obj(Map("$ne" -> a))
-      case Op.ObjectToArray(a) => O._obj(Map("$objectToArray" -> a))
-      case Op.ArrayElemAt(a, ix) => O._obj(Map("$arrayElemAt" -> O.array(List(a, O.int(ix)))))
-      case Op.Reduce(a, b, c) => O._obj(Map("$reduce" -> O.obj(Map(
-        "input" -> a,
-        "initialValue" -> b,
-        "in" -> c))))
-      case Op.ConcatArrays(a) => O._obj(Map("$concatArrays" -> O.array(a)))
-      case Op.Not(a) => O._obj(Map("$not" -> a))
-    }
-  }
-
-  def compileOps[T[_[_]]: BirecursiveT](inp: T[CoreOp]): T[Core] =
-    inp.transCata[T[Core]](_.run.fold(opsToCore[T], (x => x)))
-
-  def coreToBson[T[_[_]]: BirecursiveT](inp: T[Core]): BsonValue = {
-    import scala.collection.JavaConverters._
-
-    def ϕ: Algebra[Core, BsonValue] = {
-      case Core.Null() =>
-        new BsonNull()
-      case Core.Int(i) =>
-        new BsonInt32(i)
-      case Core.String(s) =>
-        new BsonString(s)
-      case Core.Bool(b) =>
-        new BsonBoolean(b)
-      case Core.Array(as) =>
-        new BsonArray(as.asJava)
-      case Core.Object(mp) =>
-        val elems = mp.toList map {
-          case (key, v) => new BsonElement(key, v)
-        }
-        new BsonDocument(elems.asJava)
-    }
-    inp.cata[BsonValue](ϕ)
-  }
-
-  def optimize[T[_[_]]: BirecursiveT](inp: T[CoreOp]): T[CoreOp] = {
-    orOpt(letOpt(inp))
-  }
-
-  def letOpt[T[_[_]]: BirecursiveT](inp: T[CoreOp]): T[CoreOp] = {
-    val O = Optics.coreOp(Prism.id[CoreOp[T[CoreOp]]])
-    val τ: CoreOp[T[CoreOp]] => CoreOp[T[CoreOp]] = {
-      case O.$let(vars, in) =>
-        if (vars.size /== 1) O.$let(vars, in)
-        else in.project match {
-          case O.string(str) =>
-            vars.get(str.stripPrefix("$$")) map (_.project) match {
-              case Some(O.string(x)) if x.stripPrefix("$") /== x =>
-                O.string(x.concat(x))
+  def letOpt[W: Basis[CoreOp, ?], U: Basis[CoreOp, ?]]: W => U = {
+    val o = Optics.coreOp(Optics.basisPrism[CoreOp, U])
+    val f = Optics.coreOp(Prism.id[CoreOp[U]])
+    import o._
+    scheme.cata[CoreOp, W, U](Algebra {
+      case l @ f.let(vars, in) =>
+        if (vars.size =!= 1) let(vars, in)
+        else in match {
+          case str(k) =>
+            vars.get(k.stripPrefix("$$")) match {
+              case Some(str(v)) if v.stripPrefix("$") =!= v =>
+                str(v.concat(v))
               case _ =>
-                O.$let(vars, in)
+                let(vars, in)
             }
-          case _ => O.$let(vars, in)
+          case _ =>
+            let(vars, in)
         }
-      case x => x
-    }
-    inp.transCata[T[CoreOp]](τ)
+      case x => x.embed
+    })
   }
 
-  def orOpt[T[_[_]]: BirecursiveT](inp: T[CoreOp]): T[CoreOp] = {
-    val O = Optics.coreOp(Prism.id[CoreOp[T[CoreOp]]])
-    val τ: CoreOp[T[CoreOp]] => CoreOp[T[CoreOp]] = {
-      case O.$or(lst) => lst match {
-        case List() => O.bool(false)
-        case List(a) => a.project
-        case _ => O.$or(lst map (_.project) flatMap {
-          case O.$or(as) => as
-          case x => List(x.embed)
+  def orOpt[W: Basis[CoreOp, ?], U: Basis[CoreOp, ?]]: W => U = {
+    val o = Optics.coreOp(Optics.basisPrism[CoreOp, U])
+    val f = Optics.coreOp(Prism.id[CoreOp[U]])
+    import o._
+    scheme.cata[CoreOp, W, U](Algebra {
+      case f.or(lst) => lst match {
+        case List() => bool(false)
+        case List(a) => a
+        case _ => or(lst flatMap {
+          case or(as) => as
+          case x => List(x)
         })
       }
-      case x => x
-    }
-    inp.transCata[T[CoreOp]](τ)
+      case x => x.embed
+    })
+  }
+  def mapProjection[F[a] <: ACopK[a], W, U](fn: Projection => Projection)(
+      implicit
+      F: Functor[F],
+      I: Const[Projection, ?] :<<: F,
+      Q: Basis[F, W],
+      P: Basis[F, U])
+      : W => U = {
+    val o = Optics.projection(Optics.basisPrism[F, U] composePrism Optics.copkPrism[Const[Projection, ?], F, U])
+    val f = Optics.projection(Optics.copkPrism[Const[Projection, ?], F, U])
+    scheme.cata[F, W, U](Algebra {
+      case f.projection(prj) =>
+        o.projection(fn(prj))
+      case x =>
+        x.embed
+    })
   }
 
-  def mapProjection[T[_[_]]: BirecursiveT](f: Projection => Projection)(inp: T[ExprF]): T[ExprF] = {
-    val O = Optics.full(Prism.id[ExprF[T[ExprF]]])
-    val τ: ExprF[T[ExprF]] => ExprF[T[ExprF]] = {
-      case O.projection(prj) => O.projection(f(prj))
-      case x => x
+  def coreToBson[U: Basis[Core0, ?]]: U => BsonValue = {
+    import scala.collection.JavaConverters._
+    scheme.cata[Core0, U, BsonValue](Algebra { x =>
+      CopK.RemoveL[Core, CoreL].apply(x) match {
+        case Right(a) => a match {
+          case Core.Null() =>
+            new BsonNull()
+          case Core.SInt(i) =>
+            new BsonInt32(i)
+          case Core.SString(s) =>
+            new BsonString(s)
+          case Core.Bool(b) =>
+            new BsonBoolean(b)
+          case Core.Array(as) =>
+            new BsonArray(as.asJava)
+          case Core.Object(mp) =>
+            val elems = mp.toList.map {
+              case (k, v) => new BsonElement(k, v)
+            }
+            new BsonDocument(elems.asJava)
+        }
+        case Left(_) => throw new Throwable("impossible")
+    }})
+  }
+
+  def compile[F[_]: MonoidK: Monad, U: Basis[Expr, ?]](
+      version: Version,
+      uuid: String,
+      pipes: List[Pipeline[U]]): F[List[BsonDocument]] =
+    pipes.flatMap(eraseCustomPipeline[Expr, U](uuid, _)).traverse { (pipe: MongoPipeline[U]) =>
+      if (version < pipe.minVersion) MonoidK[F].empty
+      else {
+        val exprs = pipelineObjects[Expr, U](pipe)
+        val coreop: Fix[CoreOp] = compileProjections[U, Fix[CoreOp]](uuid).apply(exprs)
+        val optimized = (letOpt[Fix[CoreOp], Fix[CoreOp]] andThen orOpt[Fix[CoreOp], Fix[CoreOp]])(coreop)
+        val opVersion = coreOpMinVersion[Fix[CoreOp]].apply(optimized)
+        if (opVersion > version) MonoidK[F].empty
+        else {
+          val core: Fix[Core0] = compileOp[Fix[CoreOp], Fix[Core0]].apply(optimized)
+          val bsonValue = coreToBson[Fix[Core0]].apply(core)
+          onlyDocuments[F](bsonValue)
+        }
+      }
     }
-    inp.transCata[T[ExprF]](τ)
+
+  def onlyDocuments[F[_]: MonoidK: Applicative](inp: BsonValue): F[BsonDocument] = inp match {
+    case x: BsonDocument => x.pure[F]
+    case _ => MonoidK[F].empty
   }
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
@@ -79,8 +79,8 @@ object Core {
         case (k, v) => NonTerminal(List(), Some(k), List(fa.render(v)))
       })
       case Bool(a) => Terminal(List("Boolean"), Some(a.toString))
-      case Int(a) => Terminal(List("s.Int"), Some(a.toString))
-      case String(a) => Terminal(List("s.String"), Some(a))
+      case Int(a) => Terminal(List("Int"), Some(a.toString))
+      case String(a) => Terminal(List("String"), Some(a))
       case Null() => Terminal(List("Null"), None)
     }
   }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
@@ -16,7 +16,7 @@
 
 package quasar.physical.mongo.expression
 
-import slamdata.Predef.{Eq => _, _}
+import slamdata.{Predef => s}, s.{Int => _, String => _, Eq => _, _}
 
 import quasar.{RenderTree, NonTerminal, Terminal}
 
@@ -30,10 +30,10 @@ sealed trait Core[A] extends Product with Serializable
 
 object Core {
   final case class Array[A](value: List[A]) extends Core[A]
-  final case class Object[A](value: Map[String, A]) extends Core[A]
+  final case class Object[A](value: Map[s.String, A]) extends Core[A]
   final case class Bool[A](value: Boolean) extends Core[A]
-  final case class SInt[A](value: Int) extends Core[A]
-  final case class SString[A](value: String) extends Core[A]
+  final case class Int[A](value: s.Int) extends Core[A]
+  final case class String[A](value: s.String) extends Core[A]
   final case class Null[A]() extends Core[A]
 
 
@@ -42,8 +42,8 @@ object Core {
       case Array(v) => v.traverse(f).map(Array(_))
       case Object(v) => v.toList.traverse(_.traverse(f)).map(x => Object(x.toMap))
       case Bool(v) => (Bool(v): Core[B]).pure[G]
-      case SInt(v) => (SInt(v): Core[B]).pure[G]
-      case SString(v) => (SString(v): Core[B]).pure[G]
+      case Int(v) => (Int(v): Core[B]).pure[G]
+      case String(v) => (String(v): Core[B]).pure[G]
       case Null() => (Null(): Core[B]).pure[G]
     }
   }
@@ -54,13 +54,13 @@ object Core {
     val _array =
       Prism.partial[Core[A], List[A]]{case Array(v) => v}(Array(_))
     val _obj =
-      Prism.partial[Core[A], Map[String, A]]{case Object(v) => v}(Object(_))
+      Prism.partial[Core[A], Map[s.String, A]]{case Object(v) => v}(Object(_))
     val _bool =
       Prism.partial[Core[A], Boolean]{case Bool(v) => v}(Bool(_))
     val _int =
-      Prism.partial[Core[A], Int]{case SInt(v) => v}(SInt(_))
+      Prism.partial[Core[A], s.Int]{case Int(v) => v}(Int(_))
     val _str =
-      Prism.partial[Core[A], String]{case SString(v) => v}(SString(_))
+      Prism.partial[Core[A], s.String]{case String(v) => v}(String(_))
     val _nil =
       Prism.partial[Core[A], Unit]{case Null() => ()}(x => Null())
 
@@ -79,8 +79,8 @@ object Core {
         case (k, v) => NonTerminal(List(), Some(k), List(fa.render(v)))
       })
       case Bool(a) => Terminal(List("Boolean"), Some(a.toString))
-      case SInt(a) => Terminal(List("Int"), Some(a.toString))
-      case SString(a) => Terminal(List("String"), Some(a))
+      case Int(a) => Terminal(List("s.Int"), Some(a.toString))
+      case String(a) => Terminal(List("s.String"), Some(a))
       case Null() => Terminal(List("Null"), None)
     }
   }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Core.scala
@@ -16,78 +16,60 @@
 
 package quasar.physical.mongo.expression
 
-import slamdata.Predef.{String => SString, Int => SInt, _}
-
-import matryoshka.Delay
-
-import monocle.Prism
+import slamdata.Predef.{Eq => _, _}
 
 import quasar.{RenderTree, NonTerminal, Terminal}
 
-import scalaz.{Traverse, Applicative, Scalaz}, Scalaz._
-import scalaz.syntax._
+import cats._
+import cats.implicits._
+import higherkindness.droste.Delay
+import higherkindness.droste.util.DefaultTraverse
+import monocle.Prism
 
-trait Core[A] extends Product with Serializable
+sealed trait Core[A] extends Product with Serializable
 
 object Core {
-  final case class Array[A](arr: List[A]) extends Core[A]
-  final case class Object[A](obj: Map[SString, A]) extends Core[A]
-  final case class Bool[A](bool: Boolean) extends Core[A]
-  final case class Int[A](int: SInt) extends Core[A]
-  final case class String[A](string: SString) extends Core[A]
+  final case class Array[A](value: List[A]) extends Core[A]
+  final case class Object[A](value: Map[String, A]) extends Core[A]
+  final case class Bool[A](value: Boolean) extends Core[A]
+  final case class SInt[A](value: Int) extends Core[A]
+  final case class SString[A](value: String) extends Core[A]
   final case class Null[A]() extends Core[A]
 
-  implicit def traverse: Traverse[Core] = new Traverse[Core] {
-    def traverseImpl[G[_]: Applicative, A, B](core: Core[A])(f: A => G[B])
-        : G[Core[B]] = core match {
 
-      case Null() => (Null(): Core[B]).point[G]
-      case String(s) => (String(s): Core[B]).point[G]
-      case Int(i) => (Int(i): Core[B]).point[G]
-      case Bool(b) => (Bool(b): Core[B]).point[G]
-      case Object(o) => o traverse f map (Object(_))
-      case Array(a) => a traverse f map (Array(_))
+  implicit def traverse: Traverse[Core] = new DefaultTraverse[Core] {
+    def traverse[G[_]: Applicative, A, B](fa: Core[A])(f: A => G[B]): G[Core[B]] = fa match {
+      case Array(v) => v.traverse(f).map(Array(_))
+      case Object(v) => v.toList.traverse(_.traverse(f)).map(x => Object(x.toMap))
+      case Bool(v) => (Bool(v): Core[B]).pure[G]
+      case SInt(v) => (SInt(v): Core[B]).pure[G]
+      case SString(v) => (SString(v): Core[B]).pure[G]
+      case Null() => (Null(): Core[B]).pure[G]
     }
   }
 
   trait Optics[A, O] {
-    val corePrism: Prism[O, Core[A]]
-    val _array: Prism[Core[A], List[A]] =
-      Prism.partial[Core[A], List[A]] {
-        case Array(a) => a
-      } { a => Array(a) }
+    val core: Prism[O, Core[A]]
 
-    val _obj: Prism[Core[A], Map[SString, A]] =
-      Prism.partial[Core[A], Map[SString, A]] {
-        case Object(a) => a
-      } { a => Object(a) }
+    val _array =
+      Prism.partial[Core[A], List[A]]{case Array(v) => v}(Array(_))
+    val _obj =
+      Prism.partial[Core[A], Map[String, A]]{case Object(v) => v}(Object(_))
+    val _bool =
+      Prism.partial[Core[A], Boolean]{case Bool(v) => v}(Bool(_))
+    val _int =
+      Prism.partial[Core[A], Int]{case SInt(v) => v}(SInt(_))
+    val _str =
+      Prism.partial[Core[A], String]{case SString(v) => v}(SString(_))
+    val _nil =
+      Prism.partial[Core[A], Unit]{case Null() => ()}(x => Null())
 
-    val _bool: Prism[Core[A], Boolean] =
-      Prism.partial[Core[A], Boolean] {
-        case Bool(a) => a
-      } { a => Bool(a) }
-
-    val _int: Prism[Core[A], SInt] =
-      Prism.partial[Core[A], SInt] {
-        case Int(a) => a
-      } { a => Int(a) }
-
-    val _string: Prism[Core[A], SString] =
-      Prism.partial[Core[A], SString] {
-        case String(a) => a
-      } { a => String(a) }
-
-    val _nil: Prism[Core[A], Unit] =
-      Prism.partial[Core[A], Unit] {
-        case Null() => ()
-      } { x => Null() }
-
-    val array: Prism[O, List[A]] = corePrism composePrism _array
-    val obj: Prism[O, Map[SString, A]] = corePrism composePrism _obj
-    val bool: Prism[O, Boolean] = corePrism composePrism _bool
-    val int: Prism[O, SInt] = corePrism composePrism _int
-    val string: Prism[O, SString] = corePrism composePrism _string
-    val nil: Prism[O, Unit] = corePrism composePrism _nil
+    val array = core composePrism _array
+    val obj = core composePrism _obj
+    val bool = core composePrism _bool
+    val int = core composePrism _int
+    val str = core composePrism _str
+    val nil = core composePrism _nil
   }
 
   implicit val delayRenderTreeCore: Delay[RenderTree, Core] = new Delay[RenderTree, Core] {
@@ -97,8 +79,8 @@ object Core {
         case (k, v) => NonTerminal(List(), Some(k), List(fa.render(v)))
       })
       case Bool(a) => Terminal(List("Boolean"), Some(a.toString))
-      case Int(a) => Terminal(List("Int"), Some(a.toString))
-      case String(a) => Terminal(List("String"), Some(a))
+      case SInt(a) => Terminal(List("Int"), Some(a.toString))
+      case SString(a) => Terminal(List("String"), Some(a))
       case Null() => Terminal(List("Null"), None)
     }
   }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Optics.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Optics.scala
@@ -16,85 +16,50 @@
 
 package quasar.physical.mongo.expression
 
-import slamdata.Predef._
+import quasar.contrib.iotac._
 
-import matryoshka._
-
-import monocle.{Prism, Iso}
-
-import quasar.fp.PrismNT
-
-import scalaz.{:<:, Const, Functor}
+import cats.data.Const
+import higherkindness.droste._
+import higherkindness.droste.data._
+import higherkindness.droste.syntax.all._
+import monocle.{Iso, Prism}
 
 object Optics {
-  class CoreOptics[A, O, F[_]] private[Optics] (basePrism: Prism[O, F[A]])(implicit c: Core :<: F) extends {
-    val corePrism = basePrism composePrism PrismNT.inject[Core, F].asPrism[A]
+  def copkPrism[F[_], G[a] <: ACopK[a], A](implicit I: F :<<: G): Prism[G[A], F[A]] =
+    Prism[G[A], F[A]]((x: G[A]) => I.prj(x))((x: F[A]) => I.inj(x))
+
+  def basisIso[F[_], U: Basis[F, ?]]: Iso[U, F[U]] =
+    Iso((x: U) => x.project)((x: F[U]) => x.embed)
+
+  def basisPrism[F[_], U](implicit basis: Basis[F, U]): Prism[U, F[U]] =
+    basisIso.asPrism
+
+  def coattrFPrism[F[_], A, B] =
+    Prism.partial[CoattrF[F, A, B], F[B]]{case CoattrF.Roll(f) => f}(CoattrF.roll(_))
+
+  def projection[A, O](bp: Prism[O, Const[Projection, A]]): Projection.Optics[A, O] =
+    new { val proj = bp } with Projection.Optics[A, O]
+
+  def core[F[a] <: ACopK[a], A, O](bp: Prism[O, F[A]])(implicit c: Core :<<: F): Core.Optics[A, O] = new {
+    val core = bp composePrism copkPrism[Core, F, A]
   } with Core.Optics[A, O]
 
-  class CoreOpOptics[A, O, F[_]] private[Optics] (basePrism: Prism[O, F[A]])(
-      implicit c: Core :<: F, o: Op :<: F) extends {
-    val corePrism = basePrism composePrism PrismNT.inject[Core, F].asPrism[A]
-    val opPrism = basePrism composePrism PrismNT.inject[Op, F].asPrism[A]
-  } with Core.Optics[A, O] with Op.Optics[A, O]
+  def coreOp[F[a] <: ACopK[a], A, O](bp: Prism[O, F[A]])(implicit c: Core :<<: F, o: Op :<<: F): Core.Optics[A, O] with Op.Optics[A, O] =
+    new {
+      val core = bp composePrism copkPrism[Core, F, A]
+      val op = bp composePrism copkPrism[Op, F, A]
+    } with Core.Optics[A, O] with Op.Optics[A, O]
 
-  class FullOptics[A, O, F[_]] private[Optics] (basePrism: Prism[O, F[A]])(
-      implicit c: Core :<: F, o: Op :<: F, p: Const[Projection, ?] :<: F) extends {
-    val corePrism = basePrism composePrism PrismNT.inject[Core, F].asPrism[A]
-    val opPrism = basePrism composePrism PrismNT.inject[Op, F].asPrism[A]
-    val prjPrism = basePrism composePrism PrismNT.inject[Const[Projection, ?], F].asPrism[A]
-  }  with Core.Optics[A, O] with Op.Optics[A, O] {
-    val _steps: Iso[Const[Projection, A], List[Step]] =
-      Iso[Const[Projection, A], List[Step]] {
-        case Const(Projection(steps)) => steps
-      } { steps => Const(Projection(steps)) }
+  def full[F[a] <: ACopK[a], A, O](bp: Prism[O, F[A]])(
+      implicit
+      c: Core :<<: F,
+      o: Op :<<: F,
+      p: Const[Projection, ?] :<<: F)
+      : Core.Optics[A, O] with Op.Optics[A, O] with Projection.Optics[A, O] =
+  new {
+    val core = bp composePrism copkPrism[Core, F, A]
+    val op = bp composePrism copkPrism[Op, F, A]
+    val proj = bp composePrism copkPrism[Const[Projection, ?], F, A]
+  } with Core.Optics[A, O] with Op.Optics[A, O] with Projection.Optics[A, O]
 
-    val steps: Prism[O, List[Step]] =
-      prjPrism composeIso _steps
-
-    val _projection: Iso[Const[Projection, A], Projection] =
-      Iso[Const[Projection, A], Projection] {
-        case Const(p) => p
-      } { p => Const(p) }
-
-    val projection: Prism[O, Projection] =
-      prjPrism composeIso _projection
-
-    val key: Prism[O, String] =
-      steps composePrism {
-        Prism.partial[List[Step], String] {
-          case Field(s) :: List() => s
-        } { s => List(Field(s)) }
-      }
-  }
-
-  def core[A, O, F[_]](basePrism: Prism[O, F[A]])(implicit c: Core :<: F): CoreOptics[A, O, F] =
-    new CoreOptics(basePrism)
-
-  def coreOp[A, O, F[_]](basePrism: Prism[O, F[A]])(implicit c: Core :<: F, o: Op :<: F): CoreOpOptics[A, O, F] =
-    new CoreOpOptics(basePrism)
-
-  def coreOpT[T[_[_]], F[_]](
-      implicit c: Core :<: F,
-      o: Op :<: F,
-      f: Functor[F],
-      t: BirecursiveT[T])
-      : CoreOpOptics[T[F], T[F], F] =
-    new CoreOpOptics(birecursiveIso[T[F], F].reverse.asPrism)
-
-  def full[A, O, F[_]](basePrism: Prism[O, F[A]])(
-      implicit c: Core :<: F,
-      o: Op :<: F,
-      p: Const[Projection, ?] :<: F)
-      : FullOptics[A, O, F] = {
-    new FullOptics(basePrism)
-  }
-
-  def fullT[T[_[_]], F[_]](
-      implicit c: Core :<: F,
-      o: Op :<: F,
-      p: Const[Projection, ?] :<: F,
-      f: Functor[F],
-      t: BirecursiveT[T])
-      : FullOptics[T[F], T[F], F] =
-    new FullOptics(birecursiveIso[T[F], F].reverse.asPrism)
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Projection.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Projection.scala
@@ -21,80 +21,126 @@ import slamdata.Predef._
 import quasar.common.{CPath, CPathField, CPathIndex}
 import quasar.{RenderTree, NonTerminal, Terminal}, RenderTree.ops._
 
-import scalaz.{Order, Ordering, Scalaz}, Scalaz._
+import cats._
+import cats.data.Const
+import cats.implicits._
+import monocle.{Iso, Prism}
 
-object Projection {
-  trait Step extends Product with Serializable {
-    def keyPart: String
+final case class Projection(steps: List[Projection.Step]) {
+  def +(prj: Projection): Projection = Projection(steps ++ prj.steps)
+  def toKey: String = steps match {
+    case List() => "$$ROOT"
+    case hd :: tail => tail.foldLeft(hd.keyPart){(acc, x) => s"$acc.${x.keyPart}"}
   }
 
+  def toCPath: CPath = CPath(steps map {
+    case Projection.Step.Field(s) => CPathField(s)
+    case Projection.Step.Index(i) => CPathIndex(i)
+  })
+}
+
+object Projection {
+  sealed trait Step extends Product with Serializable {
+    def keyPart: String
+  }
   object Step {
     final case class Field(name: String) extends Step {
       def keyPart: String = name
     }
-
     final case class Index(ix: Int) extends Step {
       def keyPart: String = ix.toString
+    }
+
+    implicit val order: Order[Step] = new Order[Step] {
+      def compare(a: Step, b: Step): Int = (a, b) match {
+        case (Field(_), Index(_)) => -1
+        case (Field(a), Field(b)) => Order[String].compare(a, b)
+        case (Index(_), Field(_)) => 1
+        case (Index(a), Index(b)) => Order[Int].compare(a, b)
+        case (_, _) => -1
+      }
     }
 
     implicit val renderTreeStep: RenderTree[Step] = RenderTree.make {
       case Field(s) => Terminal(List("Field"), Some(s))
       case Index(i) => Terminal(List("Index"), Some(i.toString))
     }
-
-    implicit val orderStep: Order[Step] = new Order[Step] {
-      def order(a: Step, b: Step) = a match {
-        case Field(x) => b match {
-          case Field(y) => Order[String].order(x, y)
-          case Index(_) => Ordering.LT
-        }
-        case Index(x) => b match {
-          case Index(y) => Order[Int].order(x, y)
-          case Field(_) => Ordering.GT
-        }
-      }
-    }
   }
-
   import Step._
-
-  implicit val renderTreeProjection: RenderTree[Projection] = RenderTree.make { x =>
-    NonTerminal(List("Projection"), None, x.steps map (_.render))
-  }
+  implicit val order: Order[Projection] = Order.by(_.steps)
 
   def key(s: String): Projection = Projection(List(Field(s)))
-
   def index(i: Int): Projection = Projection(List(Index(i)))
 
-  implicit val orderProjection: Order[Projection] = new Order[Projection] {
-    def order(a: Projection, b: Projection): Ordering =
-      Order[List[Step]].order(a.steps.toList, b.steps.toList)
-  }
-
   def safeField(str: String): Option[Field] =
-    if ((str contains ".") || (str contains "$")) None
+    if (str.contains(".") || str.contains("$")) None
     else Some(Field(str))
 
   def safeCartouches[A](inp: Map[CPathField, (CPathField, A)]): Option[Map[Field, (Field, A)]] =
-    inp.toList.foldlM(Map.empty[Field, (Field, A)]){ acc => {
-      case (alias, (focus, lst)) => for {
-        newAlias <- safeField(alias.name)
-        newFocus <- safeField(focus.name)
-      } yield acc.updated(newAlias, (newFocus, lst))
-    }}
+    inp.toList.foldLeftM(Map.empty[Field, (Field, A)]){ (acc, x) =>
+      x match {
+        case (alias, (focus, lst)) => for {
+          newAlias <- safeField(alias.name)
+          newFocus <- safeField(focus.name)
+        } yield acc.updated(newAlias, (newFocus, lst))
+      }
+    }
 
-  def fromCPath(cpath: CPath): Option[Projection] =
-    cpath.nodes.foldMapM {
-      case CPathField(str) => safeField(str) map (List(_))
+  def fromCPath(cpath: CPath): Option[Projection] = {
+    val steps = cpath.nodes.foldMapM {
+      case CPathField(str) => safeField(str).map(List(_))
       case CPathIndex(ix) => Some(List(Index(ix)))
       case _ => None
-    } map (Projection(_))
-}
+    }
+    steps.map(Projection(_))
+  }
 
-final case class Projection(steps: List[Projection.Step]) extends Product with Serializable {
-  def +(prj: Projection): Projection = Projection(steps ++ prj.steps)
-  def toKey: String = steps match {
-    case List() => "$$ROOT"
-    case hd :: tail => tail.foldl(hd.keyPart){ acc => x => acc concat "." concat x.keyPart }
+  trait Grouped extends Product with Serializable
+
+  object Grouped {
+    final case class IndexGroup(i: Int) extends Grouped
+    final case class FieldGroup(s: List[String]) extends Grouped
+
+    def apply(p: Projection): List[Grouped] = {
+      val accum = p.steps.foldLeft((List[String](), List[Grouped]())) { (acc, step) =>
+        acc match {
+          case (fldAccum, acc) => step match {
+            case Field(s) => (s :: fldAccum, acc)
+            case Index(i) => (List(), IndexGroup(i) :: FieldGroup(fldAccum.reverse) :: acc)
+          }
+        }
+      }
+      val reversed = accum._1 match {
+        case List() => accum._2.reverse
+        case x => (FieldGroup(x.reverse) :: accum._2).reverse
+      }
+      reversed.reverse
+    }
+  }
+
+  trait Optics[A, O] {
+    val proj: Prism[O, Const[Projection, A]]
+
+    val _projection =
+      Iso[Const[Projection, A], Projection](_.getConst)(Const(_))
+    val projection =
+      proj composePrism _projection.asPrism
+
+    val _steps =
+      Iso[Projection, List[Step]](_.steps)(Projection(_))
+
+    val steps =
+      projection composeIso _steps
+
+    val key: Prism[O, String] =
+      steps composePrism {
+        Prism.partial[List[Step], String] {
+          case Field(s) :: List() => s
+        } { s => List(Field(s)) }
+      }
+  }
+
+  implicit val renderTreeProjection: RenderTree[Projection] = RenderTree.make { x =>
+    NonTerminal(List("Projection"), None, x.steps map (_.render))
   }
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/expression/Projection.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/expression/Projection.scala
@@ -57,7 +57,6 @@ object Projection {
         case (Field(a), Field(b)) => Order[String].compare(a, b)
         case (Index(_), Field(_)) => 1
         case (Index(a), Index(b)) => Order[Int].compare(a, b)
-        case (_, _) => -1
       }
     }
 

--- a/datasource/src/main/scala/quasar/physical/mongo/interpreter/InterpretationState.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/interpreter/InterpretationState.scala
@@ -20,4 +20,4 @@ import slamdata.Predef._
 
 import quasar.physical.mongo.expression.Mapper
 
-final case class InterpretationState(uniqueKey: String, mapper: Mapper) extends Product with Serializable
+final case class InterpretationState(uniqueKey: String, mapper: Mapper)

--- a/datasource/src/main/scala/quasar/physical/mongo/interpreter/Pivot.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/interpreter/Pivot.scala
@@ -18,95 +18,85 @@ package quasar.physical.mongo.interpreter
 
 import slamdata.Predef._
 
-import quasar.IdStatus
+import quasar.{ScalarStage, IdStatus}
 import quasar.api.ColumnType
+import quasar.contrib.iotac._
+import quasar.physical.mongo.Interpreter
 import quasar.physical.mongo.expression._
 
-import scalaz.{MonadState, Scalaz}, Scalaz._
+import cats._
+import cats.implicits._
+import cats.mtl.MonadState
+import cats.mtl.implicits._
+import higherkindness.droste.Basis
 
 object Pivot {
-  def ensureArray(vectorType: ColumnType.Vector, key: String, undefined: Expr): Pipe = {
-    val proj = O.steps(List())
-    Pipeline.$project(Map(key -> (vectorType match {
-      // if proj === {} or its type isn't "object" this emits [{k: missing, v: missing}]
-      case ColumnType.Object =>
-        O.$cond(
-          O.$or(List(O.$not(O.$eq(List(O.$type(proj), O.string("object")))), O.$eq(List(proj, O.obj(Map()))))),
-          O.array(List(O.obj(Map("k" -> undefined, "v" -> undefined)))),
-          O.$objectToArray(O.steps(List())))
-      // if proj === [] or its type isn't "array" this emits [missing]
-      case ColumnType.Array =>
-        O.$cond(
-          O.$or(List(O.$not(O.$eq(List(O.$type(proj), O.string("array")))), O.$eq(List(proj, O.array(List()))))),
-          O.array(List(undefined)),
-          proj)
-    })))
-  }
-
-  def mkValue(
-      status: IdStatus,
-      vectorType: ColumnType.Vector,
-      unwinded: String,
-      index: String,
-      undefined: Expr)
-      : Expr = {
-    val indexString = O.string("$" concat index)
-    val unwindString = O.string("$" concat unwinded)
-    val kString = O.string("$" concat unwinded concat ".k")
-    val vString = O.string("$" concat unwinded concat ".v")
-    vectorType match {
-      case ColumnType.Array => status match {
-        // if we have `missing` in values then index has no sense, it's `missing` too
-        case IdStatus.IdOnly =>
-          O.$cond(
-            O.$eq(List(unwindString, undefined)),
-            undefined,
-            indexString)
-        case IdStatus.ExcludeId =>
-          unwindString
-        // the same as above, but we erase whole [id, val] instead of elements
-        case IdStatus.IncludeId =>
-          O.$cond(
-            O.$eq(List(unwindString, undefined)),
-            undefined,
-            O.array(List(indexString, unwindString)))
+  def apply[F[_]: Monad: MonadInState, U: Basis[Expr, ?]]: Interpreter[F, U, ScalarStage.Pivot] =
+    new Interpreter[F, U, ScalarStage.Pivot] {
+      def apply(s: ScalarStage.Pivot): F[List[Pipeline[U]]] = s match { case ScalarStage.Pivot(status, vectorType) =>
+        for {
+          state <- MonadState[F, InterpretationState].get
+          res = mkPipes(status, vectorType, state)
+          _ <- focus[F]
+        } yield res.map(_.map(Compiler.mapProjection[Expr, U, U](state.mapper.projection)))
       }
-      case ColumnType.Object => status match {
-        // no handling in kString, vString, they could be defined as missing in `ensureArray`
-        case IdStatus.IdOnly => kString
-        case IdStatus.ExcludeId => vString
-        case IdStatus.IncludeId =>
-          // if value is `missing` whole [id, val] is `missing`
-          O.$cond(
-            O.$eq(List(vString, undefined)),
-            undefined,
-            O.array(List(kString, vString)))
+      def ensureArray(vectorType: ColumnType.Vector, key: String, undefined: U): Pipeline[U] ={
+        val proj = o.projection(Projection(List()))
+        Pipeline.Project(Map(key -> (vectorType match {
+          case ColumnType.Object =>
+            o.cond(
+              o.or(List(o.not(o.eqx(List(o.typ(proj), o.str("object")))), o.eqx(List(proj, o.obj(Map()))))),
+              o.array(List(o.obj(Map("k" -> undefined, "v" -> undefined)))),
+              o.objectToArray(o.projection(Projection(List()))))
+          case ColumnType.Array =>
+            o.cond(
+              o.or(List(o.not(o.eqx(List(o.typ(proj), o.str("array")))), o.eqx(List(proj, o.array(List()))))),
+              o.array(List(undefined)),
+              proj)
+        })))
+      }
+
+      def mkValue(status: IdStatus, vectorType: ColumnType.Vector, unwinded: String, index: String, undefined: U): U = {
+        val indexString = o.str("$".concat(index))
+        val unwindString = o.str("$".concat(unwinded))
+        val kString = o.str("$".concat(unwinded).concat(".k"))
+        val vString = o.str("$".concat(unwinded).concat(".v"))
+        vectorType match {
+          case ColumnType.Array => status match {
+            case IdStatus.IdOnly =>
+              o.cond(
+                o.eqx(List(unwindString, undefined)),
+                undefined,
+                indexString)
+            case IdStatus.ExcludeId =>
+              unwindString
+            case IdStatus.IncludeId =>
+              o.cond(
+                o.eqx(List(unwindString, undefined)),
+                undefined,
+                o.array(List(indexString, unwindString)))
+          }
+          case ColumnType.Object => status match {
+            case IdStatus.IdOnly => kString
+            case IdStatus.ExcludeId => vString
+            case IdStatus.IncludeId =>
+              o.cond(
+                o.eqx(List(vString, undefined)),
+                undefined,
+                o.array(List(kString, vString)))
+          }
+        }
+      }
+      def mkPipes(status: IdStatus, vectorType: ColumnType.Vector, state: InterpretationState): List[Pipeline[U]] = {
+        val unwindKey = state.uniqueKey.concat("_unwind")
+        val indexKey = state.uniqueKey.concat("_unwind_index")
+        List(
+          ensureArray(vectorType, unwindKey, missing[Expr, U](state.uniqueKey)),
+          Pipeline.Unwind(unwindKey, indexKey),
+          Pipeline.Project(Map(
+            "_id" -> o.int(0),
+            state.uniqueKey -> mkValue(status, vectorType, unwindKey, indexKey, missing[Expr, U](state.uniqueKey)))),
+          Pipeline.Presented)
       }
     }
-  }
-
-  def mkPipes(
-      status: IdStatus,
-      vectorType: ColumnType.Vector,
-      state: InterpretationState)
-      : List[Pipe] = {
-    val unwindKey = state.uniqueKey concat "_unwind"
-    val indexKey = state.uniqueKey concat "_unwind_index"
-
-    List(
-      ensureArray(vectorType, unwindKey, missing(state.uniqueKey)),
-      Pipeline.$unwind(unwindKey, indexKey),
-      Pipeline.$project(Map(
-        "_id" -> O.int(0),
-        state.uniqueKey -> mkValue(status, vectorType, unwindKey, indexKey, missing(state.uniqueKey)))),
-      Pipeline.Presented)
-  }
-
-
-  def apply[F[_]: MonadInState](status: IdStatus, vectorType: ColumnType.Vector): F[List[Pipe]] =
-    for {
-      state <- MonadState[F, InterpretationState].get
-      res = mkPipes(status, vectorType, state)
-      _ <- focus[F]
-    } yield res map mapProjection(state.mapper)
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/interpreter/Wrap.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/interpreter/Wrap.scala
@@ -18,21 +18,33 @@ package quasar.physical.mongo.interpreter
 
 import slamdata.Predef._
 
+import quasar.ScalarStage
+import quasar.contrib.iotac._
+import quasar.physical.mongo.Interpreter
 import quasar.physical.mongo.expression._
 
-import scalaz.{MonadState, Scalaz}, Scalaz._
+import cats.{Monad, MonoidK}
+import cats.implicits._
+import cats.mtl.MonadState
+import higherkindness.droste.Basis
 
 object Wrap {
-  def apply[F[_]: MonadInState](name: Field): F[List[Pipe]] = for {
-    state <- MonadState[F, InterpretationState].get
-    res = List(Pipeline.$project(Map(
-      state.uniqueKey ->
-        O.$cond(
-          O.$eq(List(O.steps(List()), missing(state.uniqueKey))),
-          missing(state.uniqueKey),
-          O.obj(Map(name.name -> O.steps(List())))),
-      "_id" -> O.int(0))),
-      Pipeline.Presented)
-    _ <- focus[F]
-  } yield res map mapProjection(state.mapper)
+  def apply[F[_]: Monad: MonadInState: MonoidK, U: Basis[Expr, ?]]
+      : Interpreter[F, U, ScalarStage.Wrap] =
+    new Interpreter[F, U, ScalarStage.Wrap] {
+      def apply(s: ScalarStage.Wrap): F[List[Pipeline[U]]] = optToAlternative[F].apply(Projection.safeField(s.name)) flatMap { name =>
+        for {
+          state <- MonadState[F, InterpretationState].get
+          (res: List[Pipeline[U]]) = List(Pipeline.Project(Map(
+            state.uniqueKey ->
+              o.cond(
+                o.eqx(List(o.projection(Projection(List())), missing[Expr, U](state.uniqueKey))),
+                missing[Expr, U](state.uniqueKey),
+                o.obj(Map(name.name -> o.projection(Projection(List()))))),
+            "_id" -> o.int(0))),
+            Pipeline.Presented)
+          _ <- focus[F]
+        } yield res.map(_.map(Compiler.mapProjection[Expr, U, U](state.mapper.projection)))
+      }
+    }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
@@ -347,7 +347,7 @@ object MongoSpec {
         MongoConfig(connectionStringInvalidPort, 64, PushdownLevel.Full, None, None),
         blocker)
 
-      interpreter = new Interpreter(Version(0, 0, 0), "redundant", PushdownLevel.Full)
+      interpreter = Interpreter.interpret(Version(0, 0, 0), PushdownLevel.Full, "redundant")
     } yield {
       new Mongo[IO](
         client, BatchSize.toLong, PushdownLevel.Full, interpreter, None)

--- a/datasource/src/test/scala/quasar/physical/mongo/interpreter/PivotSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/interpreter/PivotSpec.scala
@@ -20,56 +20,64 @@ import slamdata.Predef._
 
 import org.specs2.mutable.Specification
 
+import quasar.{IdStatus, ScalarStage}
 import quasar.api.ColumnType
+import quasar.contrib.iotac._
 import quasar.physical.mongo.expression._
-import quasar.IdStatus
 
-import scalaz.{State, Scalaz}, Scalaz._
+import cats.implicits._
+import cats.mtl.implicits._
+import higherkindness.droste.data.Fix
+
 
 class PivotSpec extends Specification with quasar.TreeMatchers {
   private def evalPivot(
       state: InterpretationState,
       idStatus: IdStatus,
       columnType: ColumnType.Vector)
-      : (Mapper, List[Pipe]) =
-    Pivot[State[InterpretationState, ?]](idStatus, columnType) run state leftMap (_.mapper)
+      : (Mapper, List[Pipeline[Fix[Expr]]]) = {
+    val interpreter = Pivot[InState, Fix[Expr]]
+    interpreter(ScalarStage.Pivot(idStatus, columnType)).run(state).get.leftMap(_.mapper)
+  }
+
+  val o = Optics.full(Optics.basisPrism[Expr, Fix[Expr]])
 
   "Array examples" >> {
     val initialState = InterpretationState("root", Mapper.Unfocus)
-    def mkExpected(e: Expr): List[Pipe] = List(
-      Pipeline.$project(Map("root_unwind" ->
-        O.$cond(
-          O.$or(List(
-            O.$not(O.$eq(List(O.$type(O.steps(List())), O.string("array")))),
-            O.$eq(List(O.steps(List()), O.array(List()))))),
-          O.array(List(O.string("root_missing"))),
-          O.steps(List())))),
-      Pipeline.$unwind("root_unwind", "root_unwind_index"),
-      Pipeline.$project(Map("_id" -> O.int(0), "root" -> e)),
+    def mkExpected(e: Fix[Expr]): List[Pipeline[Fix[Expr]]] = List(
+      Pipeline.Project(Map("root_unwind" ->
+        o.cond(
+          o.or(List(
+            o.not(o.eqx(List(o.typ(o.steps(List())), o.str("array")))),
+            o.eqx(List(o.steps(List()), o.array(List()))))),
+          o.array(List(o.str("root_missing"))),
+          o.steps(List())))),
+      Pipeline.Unwind("root_unwind", "root_unwind_index"),
+      Pipeline.Project(Map("_id" -> o.int(0), "root" -> e)),
       Pipeline.Presented)
 
     "id only" >> {
       val actual = evalPivot(initialState, IdStatus.IdOnly, ColumnType.Array)
       val expected = mkExpected(
-        O.$cond(
-          O.$eq(List(O.string("$root_unwind"), O.string("root_missing"))),
-          O.string("root_missing"),
-          O.string("$root_unwind_index")))
+        o.cond(
+          o.eqx(List(o.str("$root_unwind"), o.str("root_missing"))),
+          o.str("root_missing"),
+          o.str("$root_unwind_index")))
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
     "values only" >> {
       val actual = evalPivot(initialState, IdStatus.ExcludeId, ColumnType.Array)
-      val expected = mkExpected(O.string("$root_unwind"))
+      val expected = mkExpected(o.str("$root_unwind"))
 
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
     "both" >> {
       val actual = evalPivot(initialState, IdStatus.IncludeId, ColumnType.Array)
       val expected = mkExpected(
-        O.$cond(
-          O.$eq(List(O.string("$root_unwind"), O.string("root_missing"))),
-          O.string("root_missing"),
-          O.array(List(O.string("$root_unwind_index"), O.string("$root_unwind")))))
+        o.cond(
+          o.eqx(List(o.str("$root_unwind"), o.str("root_missing"))),
+          o.str("root_missing"),
+          o.array(List(o.str("$root_unwind_index"), o.str("$root_unwind")))))
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
   }
@@ -77,38 +85,38 @@ class PivotSpec extends Specification with quasar.TreeMatchers {
   "Object examples" >> {
     val initialState = InterpretationState("root", Mapper.Unfocus)
 
-    def mkExpected(e: Expr): List[Pipe] = List(
-      Pipeline.$project(Map("root_unwind" ->
-        O.$cond(
-          O.$or(List(
-            O.$not(O.$eq(List(O.$type(O.steps(List())), O.string("object")))),
-            O.$eq(List(O.steps(List()), O.obj(Map()))))),
-          O.array(List(O.obj(Map(
-            "k" -> O.string("root_missing"),
-            "v" -> O.string("root_missing"))))),
-          O.$objectToArray(O.steps(List()))))),
-      Pipeline.$unwind("root_unwind", "root_unwind_index"),
-      Pipeline.$project(Map("_id" -> O.int(0), "root" -> e)),
+    def mkExpected(e: Fix[Expr]): List[Pipeline[Fix[Expr]]] = List(
+      Pipeline.Project(Map("root_unwind" ->
+        o.cond(
+          o.or(List(
+            o.not(o.eqx(List(o.typ(o.steps(List())), o.str("object")))),
+            o.eqx(List(o.steps(List()), o.obj(Map()))))),
+          o.array(List(o.obj(Map(
+            "k" -> o.str("root_missing"),
+            "v" -> o.str("root_missing"))))),
+          o.objectToArray(o.steps(List()))))),
+      Pipeline.Unwind("root_unwind", "root_unwind_index"),
+      Pipeline.Project(Map("_id" -> o.int(0), "root" -> e)),
       Pipeline.Presented)
 
     "id only" >> {
       val actual = evalPivot(initialState, IdStatus.IdOnly, ColumnType.Object)
-      val expected = mkExpected(O.string("$root_unwind.k"))
+      val expected = mkExpected(o.str("$root_unwind.k"))
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
     "values only" >> {
       val actual = evalPivot(initialState, IdStatus.ExcludeId, ColumnType.Object)
-      val expected = mkExpected(O.string("$root_unwind.v"))
+      val expected = mkExpected(o.str("$root_unwind.v"))
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
     "both" >> {
       val actual = evalPivot(initialState, IdStatus.IncludeId, ColumnType.Object)
-      val expected = mkExpected(O.$cond(
-        O.$eq(List(O.string("$root_unwind.v"), O.string("root_missing"))),
-        O.string("root_missing"),
-        O.array(List(
-          O.string("$root_unwind.k"),
-          O.string("$root_unwind.v")))))
+      val expected = mkExpected(o.cond(
+        o.eqx(List(o.str("$root_unwind.v"), o.str("root_missing"))),
+        o.str("root_missing"),
+        o.array(List(
+          o.str("$root_unwind.k"),
+          o.str("$root_unwind.v")))))
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("root"))
     }
   }
@@ -118,33 +126,33 @@ class PivotSpec extends Specification with quasar.TreeMatchers {
     "array" >> {
       val actual = evalPivot(initialState, IdStatus.ExcludeId, ColumnType.Array)
       val expected = List(
-        Pipeline.$project(Map("unique_unwind" ->
-          O.$cond(
-            O.$or(List(
-              O.$not(O.$eq(List(O.$type(O.key("focused")), O.string("array")))),
-              O.$eq(List(O.key("focused"), O.array(List()))))),
-          O.array(List(O.string("unique_missing"))),
-          O.key("focused")))),
-        Pipeline.$unwind("unique_unwind", "unique_unwind_index"),
-        Pipeline.$project(Map("_id" -> O.int(0), "unique" -> O.string("$unique_unwind"))),
+        Pipeline.Project(Map("unique_unwind" ->
+          o.cond(
+            o.or(List(
+              o.not(o.eqx(List(o.typ(o.key("focused")), o.str("array")))),
+              o.eqx(List(o.key("focused"), o.array(List()))))),
+          o.array(List(o.str("unique_missing"))),
+          o.key("focused")))),
+        Pipeline.Unwind("unique_unwind", "unique_unwind_index"),
+        Pipeline.Project(Map("_id" -> o.int(0), "unique" -> o.str("$unique_unwind"))),
         Pipeline.Presented)
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("unique"))
     }
     "object" >> {
       val actual = evalPivot(initialState, IdStatus.ExcludeId, ColumnType.Object)
       val expected = List(
-        Pipeline.$project(Map("unique_unwind" ->
-          O.$cond(
-            O.$or(List(
-              O.$not(O.$eq(List(O.$type(O.key("focused")), O.string("object")))),
-              O.$eq(List(O.key("focused"), O.obj(Map()))))),
-            O.array(List(O.obj(Map(
-              "k" -> O.string("unique_missing"),
-              "v" -> O.string("unique_missing"))))),
-            O.$objectToArray(O.key("focused"))))),
+        Pipeline.Project(Map("unique_unwind" ->
+          o.cond(
+            o.or(List(
+              o.not(o.eqx(List(o.typ(o.key("focused")), o.str("object")))),
+              o.eqx(List(o.key("focused"), o.obj(Map()))))),
+            o.array(List(o.obj(Map(
+              "k" -> o.str("unique_missing"),
+              "v" -> o.str("unique_missing"))))),
+            o.objectToArray(o.key("focused"))))),
 
-        Pipeline.$unwind("unique_unwind", "unique_unwind_index"),
-        Pipeline.$project(Map("_id" -> O.int(0), "unique" -> O.string("$unique_unwind.v"))),
+        Pipeline.Unwind("unique_unwind", "unique_unwind_index"),
+        Pipeline.Project(Map("_id" -> o.int(0), "unique" -> o.str("$unique_unwind.v"))),
         Pipeline.Presented)
       (actual._2 must beTree(expected)) and (actual._1 === Mapper.Focus("unique"))
     }

--- a/datasource/src/test/scala/quasar/physical/mongo/interpreter/ProjectSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/interpreter/ProjectSpec.scala
@@ -20,63 +20,84 @@ import slamdata.Predef._
 
 import org.specs2.mutable.Specification
 
+import quasar.ScalarStage
+import quasar.contrib.iotac._
 import quasar.physical.mongo.expression._
-import quasar.physical.mongo.expression.{Projection, Pipeline}, Projection._, Pipeline._
+import quasar.physical.mongo.expression.{Projection, Pipeline => P}, Projection._, Step._
 
-import scalaz.{State, Scalaz}, Scalaz._
+import cats.implicits._
+import cats.mtl.implicits._
+import higherkindness.droste.data.Fix
 
 class ProjectSpec extends Specification with quasar.TreeMatchers {
+  val o = Optics.full(Optics.basisPrism[Expr, Fix[Expr]])
+
   "unfocused" >> {
     val foobarPrj = Projection.key("foo") + Projection.key("bar")
-    val actual = Project[State[InterpretationState, ?]](foobarPrj) run InterpretationState("root", Mapper.Unfocus)
+    val interpreter = Project[InState, Fix[Expr]]
+    val actual =
+      interpreter(ScalarStage.Project(foobarPrj.toCPath))
+        .run(InterpretationState("root", Mapper.Unfocus))
     val expected = List(
-      $project(Map("root_project0" -> O.steps(List()))),
-      $project(Map("root_project1" -> O.$cond(
-        O.$or(List(
-          O.$not(O.$eq(List(O.$type(O.key("root_project0")), O.string("object")))),
-          O.$eq(List(O.$type(O.steps(List(Field("root_project0"), Field("foo")))), O.string("missing"))))),
-        O.string("root_missing"),
-        O.steps(List(Field("root_project0"), Field("foo")))))),
-      Presented,
-      $project(Map("root_project0" -> O.$cond(
-        O.$or(List(
-          O.$not(O.$eq(List(O.$type(O.key("root_project1")), O.string("object")))),
-          O.$eq(List(O.$type(O.steps(List(Field("root_project1"), Field("bar")))), O.string("missing"))))),
-        O.string("root_missing"),
-        O.steps(List(Field("root_project1"), Field("bar")))))),
-      Presented,
-      $project(Map("root" -> O.key("root_project0"))),
-      Presented)
-    (actual._2 must beTree(expected)) and (actual._1.mapper === Mapper.Focus("root"))
+      P.Project(Map("root_project0" -> o.steps(List()))),
+      P.Project(Map("root_project1" -> o.cond(
+        o.or(List(
+          o.not(o.eqx(List(o.typ(o.key("root_project0")), o.str("object")))),
+          o.eqx(List(o.typ(o.steps(List(Field("root_project0"), Field("foo")))), o.str("missing"))))),
+        o.str("root_missing"),
+        o.steps(List(Field("root_project0"), Field("foo")))))),
+      P.Presented,
+      P.Project(Map("root_project0" -> o.cond(
+        o.or(List(
+          o.not(o.eqx(List(o.typ(o.key("root_project1")), o.str("object")))),
+          o.eqx(List(o.typ(o.steps(List(Field("root_project1"), Field("bar")))), o.str("missing"))))),
+        o.str("root_missing"),
+        o.steps(List(Field("root_project1"), Field("bar")))))),
+      P.Presented,
+      P.Project(Map("root" -> o.key("root_project0"))),
+      P.Presented)
+    actual must beLike {
+      case Some((state, pipes)) =>
+        state.mapper must_=== Mapper.Focus("root")
+        pipes must beTree(expected)
+    }
   }
   "focused" >> {
     val foo1Prj = Projection.key("foo") + Projection.index(1)
-    val actual = Project[State[InterpretationState, ?]](foo1Prj) run InterpretationState("other", Mapper.Focus("other"))
+    val interpreter = Project[InState, Fix[Expr]]
+    val actual =
+      interpreter(
+        ScalarStage.Project(foo1Prj.toCPath))
+        .run(InterpretationState("other", Mapper.Focus("other")))
     val expected = List(
-      $project(Map("other_project0" -> O.steps(List()))),
-      $project(Map("other_project1" -> O.$cond(
-        O.$or(List(
-          O.$not(O.$eq(List(O.$type(O.key("other_project0")), O.string("object")))),
-          O.$eq(List(O.$type(O.steps(List(Field("other_project0"), Field("other")))), O.string("missing"))))),
-        O.string("other_missing"),
-        O.steps(List(Field("other_project0"), Field("other")))))),
-      Presented,
-      $project(Map("other_project0" -> O.$cond(
-        O.$or(List(
-          O.$not(O.$eq(List(O.$type(O.key("other_project1")), O.string("object")))),
-          O.$eq(List(O.$type(O.steps(List(Field("other_project1"), Field("foo")))), O.string("missing"))))),
-        O.string("other_missing"),
-        O.steps(List(Field("other_project1"), Field("foo")))))),
-      Presented,
-      $project(Map("other_project1" -> O.$cond(
-        O.$or(List(
-          O.$not(O.$eq(List(O.$type(O.key("other_project0")), O.string("array")))),
-          O.$eq(List(O.$type(O.steps(List(Field("other_project0"), Index(1)))), O.string("missing"))))),
-        O.string("other_missing"),
-        O.steps(List(Field("other_project0"), Index(1)))))),
-      Presented,
-      $project(Map("other" -> O.key("other_project1"))),
-      Presented)
-    (actual._2 must beTree(expected)) and (actual._1.mapper === Mapper.Focus("other"))
+      P.Project(Map("other_project0" -> o.steps(List()))),
+      P.Project(Map("other_project1" -> o.cond(
+        o.or(List(
+          o.not(o.eqx(List(o.typ(o.key("other_project0")), o.str("object")))),
+          o.eqx(List(o.typ(o.steps(List(Field("other_project0"), Field("other")))), o.str("missing"))))),
+        o.str("other_missing"),
+        o.steps(List(Field("other_project0"), Field("other")))))),
+      P.Presented,
+      P.Project(Map("other_project0" -> o.cond(
+        o.or(List(
+          o.not(o.eqx(List(o.typ(o.key("other_project1")), o.str("object")))),
+          o.eqx(List(o.typ(o.steps(List(Field("other_project1"), Field("foo")))), o.str("missing"))))),
+        o.str("other_missing"),
+        o.steps(List(Field("other_project1"), Field("foo")))))),
+      P.Presented,
+      P.Project(Map("other_project1" -> o.cond(
+        o.or(List(
+          o.not(o.eqx(List(o.typ(o.key("other_project0")), o.str("array")))),
+          o.eqx(List(o.typ(o.steps(List(Field("other_project0"), Index(1)))), o.str("missing"))))),
+        o.str("other_missing"),
+        o.steps(List(Field("other_project0"), Index(1)))))),
+      P.Presented,
+      P.Project(Map("other" -> o.key("other_project1"))),
+      P.Presented)
+    actual must beLike {
+      case Some((state, pipes)) =>
+        state.mapper must_=== Mapper.Focus("other")
+        pipes must beTree(expected)
+    }
   }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/interpreter/WrapSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/interpreter/WrapSpec.scala
@@ -19,37 +19,52 @@ package quasar.physical.mongo.interpreter
 import slamdata.Predef._
 
 import org.specs2.mutable.Specification
-import org.specs2.ScalaCheck
 
+import quasar.ScalarStage
+import quasar.contrib.iotac._
 import quasar.physical.mongo.expression._
 
-import scalaz.{State, Scalaz}, Scalaz._
+import cats.implicits._
+import cats.mtl.implicits._
+import higherkindness.droste.data.Fix
 
-class WrapSpec extends Specification with ScalaCheck {
+class WrapSpec extends Specification with quasar.TreeMatchers {
+  val o = Optics.full(Optics.basisPrism[Expr, Fix[Expr]])
+
   "unfocused" >> {
-    val actual = Wrap[State[InterpretationState, ?]](Field("wrapper")) run InterpretationState("root", Mapper.Unfocus)
+    val interpreter = Wrap[InState, Fix[Expr]]
+    val actual = interpreter(ScalarStage.Wrap("wrapper")).run(InterpretationState("root", Mapper.Unfocus))
     val expected = List(
-      Pipeline.$project(Map(
+      Pipeline.Project(Map(
         "root" ->
-          O.$cond(
-            O.$eq(List(O.steps(List()), O.string("root_missing"))),
-            O.string("root_missing"),
-            O.obj(Map("wrapper" -> O.steps(List())))),
-        "_id" -> O.int(0))),
+          o.cond(
+            o.eqx(List(o.steps(List()), o.str("root_missing"))),
+            o.str("root_missing"),
+            o.obj(Map("wrapper" -> o.steps(List())))),
+        "_id" -> o.int(0))),
       Pipeline.Presented)
-    (actual._2 === expected) and (actual._1.mapper === Mapper.Focus("root"))
+    actual must beLike {
+      case Some((state, pipes)) =>
+        state.mapper must_=== Mapper.Focus("root")
+        pipes must beTree(expected)
+    }
   }
   "focused" >> {
-    val actual = Wrap[State[InterpretationState, ?]](Field("wrapper")) run InterpretationState("root", Mapper.Focus("root"))
+    val interpreter = Wrap[InState, Fix[Expr]]
+    val actual = interpreter(ScalarStage.Wrap("wrapper")).run(InterpretationState("root", Mapper.Focus("root")))
     val expected = List(
-      Pipeline.$project(Map(
+      Pipeline.Project(Map(
         "root" ->
-          O.$cond(
-            O.$eq(List(O.key("root"), O.string("root_missing"))),
-            O.string("root_missing"),
-            O.obj(Map("wrapper" -> O.key("root")))),
-        "_id" -> O.int(0))),
+          o.cond(
+            o.eqx(List(o.key("root"), o.str("root_missing"))),
+            o.str("root_missing"),
+            o.obj(Map("wrapper" -> o.key("root")))),
+        "_id" -> o.int(0))),
       Pipeline.Presented)
-    (actual._2 === expected) and (actual._1.mapper === Mapper.Focus("root"))
+    actual must beLike {
+      case Some((state, pipes)) =>
+        state.mapper must_=== Mapper.Focus("root")
+        pipes must beTree(expected)
+    }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/precog/quasar/pull/4662

Besides rewrite `matryoshka * coproduct->droste * iota` there are a couple of smallish changes 

+ `Int -> SInt` and `String -> SString` in `Core`. Anyways the constructors aren't supposed to be used much with all these prisms everywhere. 
+ `Interpreter` is a type `S => F[List[Pipeline[Expr]]]` that also has `val o: Optics with Optics with Optics`. 
+ Most of interpreters don't deconstruct scalar stages but work on concrete stage. E.g. `Wrap` works with `ScalarStage.Wrap` not `String`
+ A couple of static funs were made instance methods, e.g. `bson` in `Mapper`
+ I removed all `$`, that was bad idea, readability is terrible. 
+ `$eq` -> `eqx` and `$ne -> nex`, not sure, maybe it should be named differently. 
+ Removed some fancieness like `Pipe` type, optics with predefined algebra types and so on. Apparently without `T[_[_]]: Recursive` having `Pipeline[U]` everywhere seems to be OK. 
+ A bit changed compilation flow, e.g. version is checked separately with `Pipeline => Expr => CoreOp => Core` compilation, so no more `cataM`. No more `toCoreOp`, because the only place it was used `MaskSpec`. 