### PR TITLE
Mongo resource as an argument of MongoDataSource

### DIFF
--- a/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
@@ -126,8 +126,8 @@ final class Mongo[F[_]: MonadResourceErr: ConcurrentEffect: ContextShift] privat
     })
   }
 
-  def databaseExists(database: Database): Stream[F, Boolean] =
-    databases.exists(_ === database)
+  def databaseExists(database: Database): F[Boolean] =
+    databases.exists(_ === database).compile.last.map(_ getOrElse false)
 
   def collections(database: Database): Stream[F, Collection] = {
 
@@ -143,7 +143,7 @@ final class Mongo[F[_]: MonadResourceErr: ConcurrentEffect: ContextShift] privat
     }
 
     val cols = for {
-      dbExists <- databaseExists(database)
+      dbExists <- Stream.eval(databaseExists(database))
       res <- if (!dbExists) Stream.empty else
         observableAsStream(client.getDatabase(database.name).listCollectionNames(), DefaultQueueSize).map(Collection(database, _))
           .handleErrorWith(recoverAccessDenied)
@@ -155,11 +155,11 @@ final class Mongo[F[_]: MonadResourceErr: ConcurrentEffect: ContextShift] privat
     })
   }
 
-  def collectionExists(collection: Collection): Stream[F, Boolean] =
-    collections(collection.database).exists(_ === collection)
+  def collectionExists(collection: Collection): F[Boolean] =
+    collections(collection.database).exists(_ === collection).compile.last.map(_ getOrElse false)
 
   private def withCollectionExists[A](collection: Collection, obs: Observable[A]): F[Stream[F, A]] =
-    collectionExists(collection).compile.last map(_ getOrElse false) flatMap { exists =>
+    collectionExists(collection) flatMap { exists =>
       if (exists) F.point(observableAsStream(obs, batchSize))
       else MonadResourceErr.raiseError(ResourceError.pathNotFound(collection.resourcePath))
     }

--- a/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
@@ -23,7 +23,7 @@ import quasar.api.datasource.{DatasourceError, DatasourceType}, DatasourceError.
 import quasar.concurrent._
 import quasar.connector.{ByteStore, MonadResourceErr, ExternalCredentials}
 import quasar.connector.datasource.{LightweightDatasourceModule, Reconfiguration}
-import quasar.physical.mongo.Mongo.{MongoAccessDenied, MongoConnectionFailed}
+//import quasar.physical.mongo.Mongo.{MongoAccessDenied, MongoConnectionFailed}
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -32,9 +32,7 @@ import argonaut._
 
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift, Resource, Sync, Timer}
 import cats.kernel.Hash
-import cats.syntax.applicative._
-import cats.syntax.applicativeError._
-import cats.syntax.either._
+import cats.implicits._
 
 import scalaz.NonEmptyList
 
@@ -46,18 +44,6 @@ object MongoDataSourceModule extends LightweightDatasourceModule {
       kind,
       sanitizeConfig(config),
       NonEmptyList(msg))
-
-  private def mkError[F[_]](config: Json, throwable: Throwable): Error =
-    throwable match {
-      case MongoConnectionFailed((ex, _)) =>
-        DatasourceError.ConnectionFailed(kind, sanitizeConfig(config), ex)
-
-      case MongoAccessDenied((_, detail)) =>
-        DatasourceError.AccessDenied(kind, sanitizeConfig(config), detail)
-
-      case t =>
-        mkInvalidCfgError(config, t.getMessage)
-    }
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   def lightweightDatasource[F[_]: ConcurrentEffect: ContextShift: MonadResourceErr: Timer, A: Hash](
@@ -74,10 +60,8 @@ object MongoDataSourceModule extends LightweightDatasourceModule {
           .pure[Resource[F, ?]]
 
       case Right(mongoConfig) =>
-        Blocker.cached[F]("mongo-datasource")
-          .flatMap(Mongo(mongoConfig, _))
-          .attempt
-          .map(_.bimap(mkError(config, _), MongoDataSource[F](_)))
+        val mongoResource = Resource.suspend(Sync[F].delay(Blocker.cached[F]("mongo-datasource").flatMap(Mongo(mongoConfig, _))))
+        MongoDataSource(mongoResource).asRight[Error].pure[Resource[F, ?]]
     }
 
   def kind: DatasourceType = MongoDataSource.kind

--- a/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
@@ -23,7 +23,6 @@ import quasar.api.datasource.{DatasourceError, DatasourceType}, DatasourceError.
 import quasar.concurrent._
 import quasar.connector.{ByteStore, MonadResourceErr, ExternalCredentials}
 import quasar.connector.datasource.{LightweightDatasourceModule, Reconfiguration}
-//import quasar.physical.mongo.Mongo.{MongoAccessDenied, MongoConnectionFailed}
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
@@ -44,4 +44,10 @@ class MongoDataSourceModuleSpec extends EffectfulQSpec[IO] {
     RateLimiter[IO, UUID](1.0, IO.delay(UUID.randomUUID()), NoopRateLimitUpdater[IO, UUID]).flatMap(rl =>
       MongoDataSourceModule.lightweightDatasource[IO, UUID](config, rl, ByteStore.void[IO], _ => IO(None)).use(r => IO(r must beRight)))
   }
+
+  "Using unreachable config produces Right Disposable too" >>* {
+    val config = MongoConfig.basic("mongodb://unreachable/?serverSelectionTimeoutMS=1000").withBatchSize(1).asJson
+    RateLimiter[IO, UUID](1.0, IO.delay(UUID.randomUUID()), NoopRateLimitUpdater[IO, UUID]).flatMap(rl =>
+      MongoDataSourceModule.lightweightDatasource[IO, UUID](config, rl, ByteStore.void[IO], _ => IO(None)).use(r => IO(r must beRight)))
+  }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
@@ -44,14 +44,4 @@ class MongoDataSourceModuleSpec extends EffectfulQSpec[IO] {
     RateLimiter[IO, UUID](1.0, IO.delay(UUID.randomUUID()), NoopRateLimitUpdater[IO, UUID]).flatMap(rl =>
       MongoDataSourceModule.lightweightDatasource[IO, UUID](config, rl, ByteStore.void[IO], _ => IO(None)).use(r => IO(r must beRight)))
   }
-
-  "Using unreachable config produces Left invalid configuration" >>* {
-    val config = MongoConfig.basic("mongodb://unreachable/?serverSelectionTimeoutMS=1000").withBatchSize(1).asJson
-    RateLimiter[IO, UUID](1.0, IO.delay(UUID.randomUUID()), NoopRateLimitUpdater[IO, UUID]).flatMap(rl =>
-      MongoDataSourceModule.lightweightDatasource[IO, UUID](config, rl, ByteStore.void[IO], _ => IO(None)).use(r =>
-        IO(r must beLike {
-          case Left(DatasourceError.ConnectionFailed(MongoDataSource.kind, cfg, _)) =>
-            cfg must_=== config
-        })))
-  }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceSpec.scala
@@ -37,10 +37,10 @@ import testImplicits._
 
 class MongoDataSourceSpec extends EffectfulQSpec[IO] {
   def mkDataSource: Resource[IO, MongoDataSource[IO]] =
-    MongoSpec.mkMongo.map(MongoDataSource[IO](_))
+    MongoDataSource[IO](MongoSpec.mkMongo).pure[Resource[IO, ?]]
 
   val mkInaccessibleDataSource: Resource[IO, MongoDataSource[IO]] =
-    MongoSpec.mkMongoInvalidPort.map(MongoDataSource[IO](_))
+    MongoDataSource[IO](MongoSpec.mkMongoInvalidPort).pure[Resource[IO, ?]]
 
   step(MongoSpec.setupDB.unsafeRunSync())
 

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
@@ -86,13 +86,13 @@ class MongoSpec extends EffectfulQSpec[IO] {
 
   "databaseExists returns true for existing dbs" >> Fragment.foreach(MongoSpec.correctDbs)(db =>
       s"checking ${db.name}" >>* mkMongo.use { mongo =>
-        mongo.databaseExists(db).compile.lastOrError
+        mongo.databaseExists(db)
       }
   )
 
   "databaseExists returns false for non-existing dbs" >> Fragment.foreach(MongoSpec.incorrectDbs)(db =>
     s"checking ${db.name}" >>* mkMongo.use { mongo =>
-      mongo.databaseExists(db).map(!_).compile.lastOrError
+      mongo.databaseExists(db).map(!_)
     }
   )
 
@@ -124,13 +124,13 @@ class MongoSpec extends EffectfulQSpec[IO] {
 
   "collectionExists returns true for existent collections" >> Fragment.foreach(MongoSpec.correctCollections)(col =>
     s"checking ${col.database.name} :: ${col.name}" >>* mkMongo.use { mongo =>
-      mongo.collectionExists(col).compile.lastOrError
+      mongo.collectionExists(col)
     }
   )
 
   "collectionExists returns false for non-existent collections" >> Fragment.foreach(MongoSpec.incorrectCollections)(col =>
     s"checking ${col.database.name} :: ${col.name}" >>* mkMongo.use { mongo =>
-      mongo.collectionExists(col).map(!_).compile.lastOrError
+      mongo.collectionExists(col).map(!_)
     }
   )
 


### PR DESCRIPTION
We start/stop ssh tunnel as part of `Mongo` resource instantiation, if the tunnel is down then whole `Mongo` is invalid. Making `MongoDataSource` dependent on `Resource[F, Mongo[F]]` saves it from this error, i.e. tunnel problems affects only direct `evaluate` e.g. one push or one `prefixResource` call. 
`lightweightDatasource` doesn't check connectivity anymore too. 